### PR TITLE
0.10.3 Fixes for hostname

### DIFF
--- a/helpers/bash_install.sh
+++ b/helpers/bash_install.sh
@@ -2,8 +2,8 @@
 
 set -o pipefail
 
-_VERSIONNUMBER="0.10.2"
-_VERSIONDATE="May 12 2016"
+_VERSIONNUMBER="0.10.3"
+_VERSIONDATE="May 13 2016"
 
 # where to send the logfile
 LOGFILE="/var/log/tredly-install.log"
@@ -32,6 +32,7 @@ _configOptions[2]="$( getInterfaceIP "${_externalInterfaces[0]}" )/$( getInterfa
 _configOptions[3]="$( getDefaultGateway )"
 _configOptions[4]="${HOSTNAME}"
 _configOptions[5]="10.99.0.0/16"
+# TODO: remove hard coded ip and subtract from the given container subnet
 API_GUI_CONTAINER="10.99.0.253"
 
 
@@ -483,8 +484,15 @@ else
 fi
 
 ##########
-
 # use tredly to set network details
+e_note "Setting Container Subnet"
+tredly-host config container subnet "${_configOptions[5]}"
+if [[ $? -eq 0 ]]; then
+    e_success "Success"
+else
+    e_error "Failed"
+fi
+
 e_note "Setting Host Network"
 tredly-host config host network "${_configOptions[1]}" "${_configOptions[2]}" "${_configOptions[3]}"
 if [[ $? -eq 0 ]]; then
@@ -495,14 +503,6 @@ fi
 
 e_note "Setting Host Hostname"
 tredly-host config host hostname "${_configOptions[4]}"
-if [[ $? -eq 0 ]]; then
-    e_success "Success"
-else
-    e_error "Failed"
-fi
-
-e_note "Setting Container Subnet"
-tredly-host config container subnet "${_configOptions[5]}"
 if [[ $? -eq 0 ]]; then
     e_success "Success"
 else

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -836,12 +836,15 @@ function is_valid_cidr() {
 
 function is_valid_hostname() {
     local _hostname="${1}"
-    
-    if [[ "${_hostname}" =~ ^[A-Za-z0-9_-]+$ ]]; then
-        return ${E_SUCCESS}
-    else
+    # make sure length isnt > 255 chars
+    if [[ ${#_hostname} -gt 255 ]]; then
         return ${E_ERROR}
+    # match a valid hostname
+    elif [[ "${_hostname}" =~ ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$ ]]; then
+        return ${E_SUCCESS}
     fi
+    
+    return ${E_ERROR}
 }
 
 # Given an ip address and netmask, calculate the broadcast address

--- a/tredly-host
+++ b/tredly-host
@@ -18,8 +18,8 @@ declare -a _SUBCOMMANDS
 declare -A _FLAGS
 
 # versioning
-_VERSIONNUMBER="0.10.2"
-_VERSIONDATE="May 12 2016"
+_VERSIONNUMBER="0.10.3"
+_VERSIONDATE="May 13 2016"
 
 _SHOW_HELP=false
 _ARGS=($@)


### PR DESCRIPTION
Allow dots in hostname, better regex for hostname matching, error if > 255 chars in length (RFC1123)
Set container subnet before host network
Closes tredly/tredly-build#39
