### PR TITLE
Change kernel options, disable TSO system-wide

### DIFF
--- a/kernel/TREDLY
+++ b/kernel/TREDLY
@@ -1,7 +1,9 @@
 include GENERIC
 ident TREDLY
 
-nooptions       SCTP   # Stream Control Transmission Protocol
-options         VIMAGE # VNET/Vimage support
-options         RACCT  # Resource containers
-options         RCTL   # same as above
+nooptions	SCTP   # Stream Control Transmission Protocol
+options		VIMAGE # VNET/Vimage support
+options		RACCT  # Resource containers
+options		RCTL   # same as above
+nooptions	RACCT_DEFAULT_TO_DISABLED
+nomakeoptions	DEBUG

--- a/os/loader.conf
+++ b/os/loader.conf
@@ -1,4 +1,6 @@
 kern.geom.label.gptid.enable="0"
 zfs_load="YES"
-hw.bce.tso_enable=0
 kern.racct.enable=1
+
+# Disable TSO
+net.inet.tcp.tso=0


### PR DESCRIPTION
Kernel options changed to fully enable RACCT and disable debug. Part of #10 
Disable TSO system wide. Closes #39 
