### PR TITLE
0.10.5 fixes

### DIFF
--- a/helpers/bash_install.sh
+++ b/helpers/bash_install.sh
@@ -2,8 +2,8 @@
 
 set -o pipefail
 
-_VERSIONNUMBER="0.10.4"
-_VERSIONDATE="May 20 2016"
+_VERSIONNUMBER="0.10.5"
+_VERSIONDATE="May 26 2016"
 
 # where to send the logfile
 LOGFILE="/var/log/tredly-install.log"
@@ -539,7 +539,7 @@ if [[ -n "${_CONF_INSTALL[tredlyApiGit]}" ]]; then
     tredly-host config firewall clearAPIwhitelist > /dev/null
     
     IFS=',' read -ra _whitelistArray <<< "${_CONF_INSTALL[apiWhitelist]}"
-    ip
+    
     _exitCode=0
     for ip in ${_whitelistArray[@]}; do
         tredly-host config firewall addAPIwhitelist "${ip}" > /dev/null

--- a/os/crontab
+++ b/os/crontab
@@ -1,7 +1,6 @@
 SHELL=/bin/sh
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-
 # Run ZFS scrub every Sunday at 2am
 0 2 * * 0 /sbin/zpool scrub zroot
 

--- a/os/ipfw.layer4
+++ b/os/ipfw.layer4
@@ -4,5 +4,5 @@
 
 # Configure NAT and port redirection on the Tredly-Host external IP
 ipfw -q nat 1 config ip $eip same_ports log \
-redirect_port tcp $p7ip:80 80 \
-redirect_port tcp $p7ip:443 443 \
+redirect_port tcp $p7ip:80 80 `# host` \
+redirect_port tcp $p7ip:443 443 `# host`

--- a/proxy/proxy_pass/http_https
+++ b/proxy/proxy_pass/http_https
@@ -4,3 +4,4 @@ proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_intercept_errors on;
+proxy_buffering off;

--- a/tredly-host
+++ b/tredly-host
@@ -18,8 +18,8 @@ declare -a _SUBCOMMANDS
 declare -A _FLAGS
 
 # versioning
-_VERSIONNUMBER="0.10.4"
-_VERSIONDATE="May 20 2016"
+_VERSIONNUMBER="0.10.5"
+_VERSIONDATE="May 26 2016"
 
 _SHOW_HELP=false
 _ARGS=($@)


### PR DESCRIPTION
Closes tredly/tredly-host#44 - removed line containing 'ip' in the installer
Closes tredly/tredly-host#29 - turned off proxy buffering by default for HTTP(s) connections
